### PR TITLE
Removed `&& oThis`

### DIFF
--- a/bind.js
+++ b/bind.js
@@ -11,7 +11,7 @@ if (!Function.prototype.bind) {
         fToBind = this, 
         fNOP = function () {},
         fBound = function () {
-          return fToBind.apply(this instanceof fNOP && oThis
+          return fToBind.apply(this instanceof fNOP
                  ? this
                  : oThis,
                  aArgs.concat(Array.prototype.slice.call(arguments)));


### PR DESCRIPTION
has been updated. https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind

As a result of this [revision](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind$revision/747149), it seems to have been updated.

> this "&& oThis" make this polyfill behave differently with native Function.prototype.bind.

Thank you :)
